### PR TITLE
fix logger initialization error

### DIFF
--- a/starter.go
+++ b/starter.go
@@ -125,6 +125,9 @@ func (s *Starter) Run() error {
 		showHelp()
 		return nil
 	}
+	if err := s.openLogFile(); err != nil {
+		return err
+	}
 	if s.Restart {
 		return s.restart()
 	}
@@ -136,9 +139,6 @@ func (s *Starter) Run() error {
 	}
 	if s.Command == "" {
 		return errors.New("command is required")
-	}
-	if err := s.openLogFile(); err != nil {
-		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x50d427]
goroutine 1 [running]:
github.com/shogo82148/server-starter.(*Starter).logf(...)
/go/src/github.com/shogo82148/server-starter/starter.go:1000
github.com/shogo82148/server-starter.(*Starter).stop(0xc0000ba000, 0x0, 0x0)
/go/src/github.com/shogo82148/server-starter/starter.go:1089 +0x217
github.com/shogo82148/server-starter.(*Starter).Run(0xc0000ba000, 0x0, 0x0)
/go/src/github.com/shogo82148/server-starter/starter.go:132 +0x512
main.main()
/go/src/github.com/shogo82148/server-starter/cmd/start_server/main.go:16 +0xc1
```