### PR TITLE
fix locking strategy for reloading

### DIFF
--- a/starter.go
+++ b/starter.go
@@ -666,9 +666,7 @@ func (s *Starter) getSockets() []socket {
 
 // Reload XX
 func (s *Starter) Reload() error {
-	if !s.tryToLockReload() {
-		return nil
-	}
+	s.lockReload()
 	defer s.unlockReload()
 
 RETRY:


### PR DESCRIPTION
In the current implementation, the server-starter blocks reload execution while the worker is starting. 
https://github.com/shogo82148/server-starter/blob/c0dcd223619625f1e4459756bb1d7c17c11eb658/starter.go#L149-L150

If a reload signal is received while a worker is starting, the server should reload immediately after it started. However, the Reload method is implemented to go through if it is locked, so the reload instruction will not actually complete.
https://github.com/shogo82148/server-starter/blob/c0dcd223619625f1e4459756bb1d7c17c11eb658/starter.go#L669-L671

In this PR, I fixed this problem, so the Reload method waits for the lock to be released.