### PR TITLE
Fix ineffective option

### DIFF
--- a/opt.go
+++ b/opt.go
@@ -137,7 +137,9 @@ func ParseArgs(args []string) (*Starter, error) {
 	}
 	if autoRestartInterval != "" {
 		s.AutoRestartInterval, err = parseDuration(autoRestartInterval)
-		errs = append(errs, fmt.Errorf("invalid --auto-restart-interval format: %s", autoRestartInterval))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid --auto-restart-interval format: %s", autoRestartInterval))
+		}
 	}
 	if len(errs) > 0 {
 		return nil, errs

--- a/opt_test.go
+++ b/opt_test.go
@@ -115,4 +115,14 @@ func TestParseArgs(t *testing.T) {
 			t.Errorf("want 1234,2345, got %#v", s.Ports)
 		}
 	})
+
+	t.Run("AutoRestartInterval", func(t *testing.T) {
+		s, err := ParseArgs([]string{"start_server", "--auto-restart-interval", "1234"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.AutoRestartInterval != 1234*time.Second {
+			t.Errorf("want 1234s, got %s", s.AutoRestartInterval)
+		}
+	})
 }


### PR DESCRIPTION
Currently, the `--auto-restart-interval` option cannot be used: if it is set, the server-starter will fail regardless of the format of the value. I fixed this problem.