### PR TITLE
make the listener package as a seperated module

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         go:
-          - "1"
           - "1.16"
-          - "1.15"
-          - "1.14"
-          - "1.13"
-          - "1.12"
 
     steps:
       - name: Set up Go ${{ matrix.go }}
@@ -28,9 +23,26 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Test
-        run: make test
+        run: |
+          go test -v -race -coverprofile=profile.cov ./...
         env:
           GO111MODULE: "on"
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov
+          flag-name: Go-${{ matrix.go }}-${{ matrix.os }}
+          parallel: true
+
+  # notifies that all test jobs are finished.
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true
 
   goreleaser-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,9 +35,50 @@ jobs:
           flag-name: Go-${{ matrix.go }}-${{ matrix.os }}
           parallel: true
 
+  listener:
+    name: Test of the listener package
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        go:
+          - "1.16"
+          - "1.15"
+          - "1.14"
+          - "1.13"
+          - "1.12"
+
+    steps:
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: |
+          go test -v -race -coverprofile=profile.cov ./...
+        working-directory: listener
+        env:
+          GO111MODULE: "on"
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: listener/profile.cov
+          flag-name: Go-listener-${{ matrix.go }}-${{ matrix.os }}
+          parallel: true
+
   # notifies that all test jobs are finished.
   finish:
-    needs: test
+    needs:
+      - test
+      - listener
     runs-on: ubuntu-latest
     steps:
       - uses: shogo82148/actions-goveralls@v1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/shogo82148/server-starter
 
-go 1.12
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/shogo82148/server-starter
 
 go 1.16
+
+require github.com/shogo82148/server-starter/listener v0.0.0
+
+replace github.com/shogo82148/server-starter/listener => ./listener

--- a/listener/go.mod
+++ b/listener/go.mod
@@ -1,0 +1,3 @@
+module github.com/shogo82148/server-starter/listener
+
+go 1.16


### PR DESCRIPTION
the listener package is almost stable, but start_server is still unstable.
Separate them into separate modules because their release cycles are very different.