### PR TITLE
Go 1.26 is released

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,8 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         go:
-          - "1.21"
+          - "1.26"
+          - "1.25"
 
     steps:
       - name: Set up Go ${{ matrix.go }}
@@ -43,6 +44,11 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         go:
+          - "1.26"
+          - "1.25"
+          - "1.24"
+          - "1.23"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"
@@ -94,7 +100,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.21"
+          go-version: "1.26.2"
       - name: Check GoReleaser configure
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.20"
+          go-version: "1.26.2"
 
       - name: Configure AWS Credentials
         uses: fuller-inc/actions-aws-assume-role@19da35d1a3ac5e2fa44b6052f811d5e95195088b # v1.9.0
         with:
           aws-region: ap-northeast-1
-          role-to-assume: arn:aws:iam::445285296882:role/rpm-repository-users-ServerStarterRole-Q0ESSPDW3HNG 
+          role-to-assume: arn:aws:iam::445285296882:role/rpm-repository-users-ServerStarterRole-Q0ESSPDW3HNG
           role-session-tagging: true
 
       - name: Run GoReleaser

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shogo82148/server-starter
 
-go 1.20
+go 1.25.0
 
 require github.com/shogo82148/server-starter/listener v1.0.0

--- a/starter.go
+++ b/starter.go
@@ -250,17 +250,14 @@ func (s *Starter) waitSignal() {
 		syscall.SIGQUIT,
 	)
 	for sig := range ch {
-		sig := sig
 		switch sig {
 		case syscall.SIGHUP:
 			s.logf("received HUP, spawning a new worker")
 			go s.Reload()
 		default:
-			s.wg.Add(1)
-			go func() {
-				defer s.wg.Done()
+			s.wg.Go(func() {
 				s.shutdownBySignal(sig)
-			}()
+			})
 		}
 	}
 }
@@ -549,9 +546,9 @@ func (s *Starter) listen() error {
 
 		var sock socket
 		var ok bool
-		if strings.HasPrefix(port, "u") {
+		if after, ok0 := strings.CutPrefix(port, "u"); ok0 {
 			// Listen UDP Port
-			port = strings.TrimPrefix(port, "u")
+			port = after
 			hostport = net.JoinHostPort(host, port)
 			conn, err := lc.ListenPacket(s.ctx, "udp"+suffix, hostport)
 			if err != nil {
@@ -1026,12 +1023,12 @@ func (s *Starter) restart() error {
 			return nil, err
 		}
 		gens := []int{}
-		for _, line := range bytes.Split(buf, []byte{'\n'}) {
-			idx := bytes.IndexByte(line, ':')
-			if idx < 0 {
+		for line := range bytes.SplitSeq(buf, []byte{'\n'}) {
+			before, _, ok := bytes.Cut(line, []byte{':'})
+			if !ok {
 				continue
 			}
-			g, err := strconv.Atoi(string(line[:idx]))
+			g, err := strconv.Atoi(string(before))
 			if err != nil {
 				continue
 			}

--- a/starter_test.go
+++ b/starter_test.go
@@ -633,14 +633,12 @@ func Test_Logger(t *testing.T) {
 		t.Fatal(err)
 	}
 	os.Stderr = pw
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer pr.Close()
 		if _, err := io.Copy(&buf, pr); err != nil {
 			t.Error(err)
 		}
-	}()
+	})
 
 	// build the server
 	serverBinFile := filepath.Join(dir, "server")
@@ -728,8 +726,7 @@ func Test_LoggerDies(t *testing.T) {
 }
 
 func Test_RestartAndStop(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dir, err := os.MkdirTemp("", "server-starter-test")
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go minimum version requirement to 1.25.0
  * Expanded CI workflow test matrix to cover Go versions 1.22–1.26

* **Refactor**
  * Simplified string prefix checking and byte splitting operations
  * Improved goroutine lifecycle management

* **Tests**
  * Refactored test context and goroutine handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->