### PR TITLE
add support for Amazon Linux 2023

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,6 +87,16 @@ blobs:
     ids: [package-arm64]
     directory: amazonlinux/2/aarch64/go-server-starter
 
+  # Amazon Linux 2023
+  - provider: s3
+    bucket: shogo82148-rpm-temporary
+    ids: [package-amd64]
+    directory: amazonlinux/2023/x86_64/go-server-starter
+  - provider: s3
+    bucket: shogo82148-rpm-temporary
+    ids: [package-arm64]
+    directory: amazonlinux/2023/aarch64/go-server-starter
+
   # CentOS 7
   - provider: s3
     bucket: shogo82148-rpm-temporary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Amazon Linux 2023 package support for both amd64 and arm64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->