### PR TITLE
drop support of CentOS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,26 +87,6 @@ blobs:
     ids: [package-arm64]
     directory: amazonlinux/2/aarch64/go-server-starter
 
-  # CentOS 7
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-amd64]
-    directory: centos/7/x86_64/go-server-starter
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-arm64]
-    directory: centos/7/aarch64/go-server-starter
-
-  # CentOS 8
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-amd64]
-    directory: centos/8/x86_64/go-server-starter
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-arm64]
-    directory: centos/8/aarch64/go-server-starter
-
   # AlmaLinux 8
   - provider: s3
     bucket: shogo82148-rpm-temporary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Discontinued CentOS 7 and 8 RPM package artifacts. Support remains for Amazon Linux 2, AlmaLinux, and Rocky Linux distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->